### PR TITLE
Disable downsampler in case of agg namespace

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler.go
@@ -222,6 +222,6 @@ func (d *downsampler) OnUpdate(namespaces m3.ClusterNamespaces) {
 	d.metricsAppenderOpts.defaultStagedMetadatasProtos = defaultStagedMetadatasProtos
 	// Can only downsample when aggregated namespaces are available.
 	d.enabled = hasAggregatedNamespaces && !isAnyAggNamespaceDisabled
-	logger.Info(fmt.Sprintf("Downsample enabled: %v", d.enabled))
+	logger.Info(fmt.Sprintf("Downsampler enabled: %v", d.enabled))
 	d.Unlock()
 }

--- a/src/cmd/services/m3coordinator/downsample/downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler.go
@@ -174,6 +174,25 @@ func (d *downsampler) OnUpdate(namespaces m3.ClusterNamespaces) {
 		}
 	}
 
+	var isAnyAggNamespaceDisabled bool
+	for _, ns := range namespaces {
+		attrs := ns.Options().Attributes()
+		if attrs.MetricsType != storagemetadata.AggregatedMetricsType {
+			continue
+		}
+
+		downsampleOpts, err := ns.Options().DownsampleOptions()
+		if err != nil {
+			errFmt := "unable to resolve downsample options for namespace: %v"
+			logger.Error(fmt.Sprintf(errFmt, ns.NamespaceID().String()))
+			continue
+		}
+		if !downsampleOpts.All {
+			isAnyAggNamespaceDisabled = true
+			break
+		}
+	}	
+
 	autoMappingRules, err := NewAutoMappingRules(namespaces)
 	if err != nil {
 		logger.Error("could not generate automapping rules for aggregated namespaces."+
@@ -202,6 +221,7 @@ func (d *downsampler) OnUpdate(namespaces m3.ClusterNamespaces) {
 	d.Lock()
 	d.metricsAppenderOpts.defaultStagedMetadatasProtos = defaultStagedMetadatasProtos
 	// Can only downsample when aggregated namespaces are available.
-	d.enabled = hasAggregatedNamespaces
+	d.enabled = hasAggregatedNamespaces && !isAnyAggNamespaceDisabled
+	logger.Info(fmt.Sprintf("Downsample enabled: %v", d.enabled))
 	d.Unlock()
 }


### PR DESCRIPTION
Check if there's at least one aggregated namespace with downsample disabled. If so, disabled the downsample object entirely

