### PR TITLE
Replace histogram with timer

### DIFF
--- a/src/dbnode/storage/series/types.go
+++ b/src/dbnode/storage/series/types.go
@@ -415,8 +415,8 @@ type Stats struct {
 	encodersPerBlock          tally.Histogram
 	encoderLimitWriteRejected tally.Counter
 	snapshotMergesEachBucket  tally.Counter
-	acquireLockLatency        tally.Histogram
-	writeDatapointLatency     tally.Histogram
+	acquireLockLatency        tally.Timer
+	writeDatapointLatency     tally.Timer
 }
 
 // NewStats returns a new Stats for the provided scope.
@@ -425,32 +425,25 @@ func NewStats(scope tally.Scope) Stats {
 
 	buckets := append(tally.ValueBuckets{0},
 		tally.MustMakeExponentialValueBuckets(1, 2, 20)...)
-
-	lockLatencyBuckets := append(tally.ValueBuckets{0},
-		tally.MustMakeExponentialValueBuckets(1, 2, 20)...)
-
-	writeDatapointLatencyBuckets := append(tally.ValueBuckets{0},
-		tally.MustMakeExponentialValueBuckets(1, 2, 20)...)
-
 	return Stats{
 		encoderCreated:            subScope.Counter("encoder-created"),
 		coldWrites:                subScope.Counter("cold-writes"),
 		encodersPerBlock:          subScope.Histogram("encoders-per-block", buckets),
 		encoderLimitWriteRejected: subScope.Counter("encoder-limit-write-rejected"),
 		snapshotMergesEachBucket:  subScope.Counter("snapshot-merges-each-bucket"),
-		acquireLockLatency:        scope.Histogram("acquire-lock-latency", lockLatencyBuckets),
-		writeDatapointLatency:     scope.Histogram("write-datapoint-latency", writeDatapointLatencyBuckets),
+		acquireLockLatency:        scope.Timer("acquire-lock-latency"),
+		writeDatapointLatency:     scope.Timer("write-datapoint-latency"),
 	}
 }
 
 // Increase lock latency
 func (s Stats) RecordLockAcquireLatency(v time.Duration) {
-	s.acquireLockLatency.RecordDuration(v)
+	s.acquireLockLatency.Record(v)
 }
 
-// Increase dp write latency
+// Increase lock latency
 func (s Stats) RecordWriteDatapointLatency(v time.Duration) {
-	s.writeDatapointLatency.RecordDuration(v)
+	s.writeDatapointLatency.Record(v)
 }
 
 // IncCreatedEncoders incs the EncoderCreated stat.

--- a/src/dbnode/storage/series/types.go
+++ b/src/dbnode/storage/series/types.go
@@ -436,12 +436,12 @@ func NewStats(scope tally.Scope) Stats {
 	}
 }
 
-// Increase lock latency
+// Set lock latency
 func (s Stats) RecordLockAcquireLatency(v time.Duration) {
 	s.acquireLockLatency.Record(v)
 }
 
-// Increase lock latency
+// Set dp write latency
 func (s Stats) RecordWriteDatapointLatency(v time.Duration) {
 	s.writeDatapointLatency.Record(v)
 }

--- a/src/query/api/v1/handler/influxdb/write.go
+++ b/src/query/api/v1/handler/influxdb/write.go
@@ -70,10 +70,9 @@ type ingestWriteHandler struct {
 
 type influxDBWriteMetrics struct {
 	writeBatchSize    tally.Counter
-	writeSuccess      tally.Counter
 	writeErrorsServer tally.Counter
 	writeErrorsClient tally.Counter
-	writeBatchLatency tally.Histogram
+	writeBatchLatency tally.Timer
 }
 
 func (m *influxDBWriteMetrics) incError(err error) {
@@ -85,15 +84,10 @@ func (m *influxDBWriteMetrics) incError(err error) {
 }
 
 func newInfluxDBriteMetrics(scope tally.Scope) (influxDBWriteMetrics, error) {
-	writeLatencyBuckets, err := tally.ExponentialValueBuckets(1, 2, 15)
-	if err != nil {
-		return influxDBWriteMetrics{}, err
-	}
 	return influxDBWriteMetrics{
-		writeBatchSize:    scope.SubScope("write").Counter("batch-size"),
-		writeSuccess:      scope.SubScope("write").Counter("success"),
+		writeBatchSize:    scope.Counter("batch-size"),
 		writeErrorsServer: scope.SubScope("write").Tagged(map[string]string{"code": "5XX"}).Counter("errors"),
-		writeBatchLatency: scope.SubScope("write").Histogram("batch-latency", writeLatencyBuckets),
+		writeBatchLatency: scope.Timer("batch-latency"),
 	}, nil
 }
 
@@ -323,9 +317,7 @@ func NewInfluxWriterHandler(options options.HandlerOptions) http.Handler {
 }
 
 func (iwh *ingestWriteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	batchRequestStopwatch := iwh.metrics.writeBatchLatency.Start()
-	defer batchRequestStopwatch.Stop()
-
+	callStart := time.Now()
 	bytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		iwh.metrics.incError(err)
@@ -380,7 +372,7 @@ func (iwh *ingestWriteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	batchErr := iwh.handlerOpts.DownsamplerAndWriter().WriteBatch(r.Context(), iter, opts)
 	if batchErr == nil {
 		iwh.metrics.writeBatchSize.Inc(int64(len(points)))
-		iwh.metrics.writeSuccess.Inc(1)
+		iwh.metrics.writeBatchLatency.Record(time.Now().Sub(callStart))
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}


### PR DESCRIPTION
# TYPE coordinator_influxdb_write_batch_latency
coordinator_influxdb_write_batch_latency{quantile="0.5"} 0.045119809
coordinator_influxdb_write_batch_latency{quantile="0.75"} 0.072533695
coordinator_influxdb_write_batch_latency{quantile="0.95"} 0.078873057
coordinator_influxdb_write_batch_latency{quantile="0.99"} 0.078873057

# TYPE coordinator_downsampler_agg_batch_write_latency
coordinator_downsampler_agg_batch_write_latency{quantile="0.5"} 0.022193993
coordinator_downsampler_agg_batch_write_latency{quantile="0.75"} 0.024333763
coordinator_downsampler_agg_batch_write_latency{quantile="0.95"} 0.03373405
coordinator_downsampler_agg_batch_write_latency{quantile="0.99"} 0.040608545


# TYPE m3storage_database_acquire_lock_latency
m3storage_database_acquire_lock_latency{namespace="default",quantile="0.5"} 1.52e-07
m3storage_database_acquire_lock_latency{namespace="default",quantile="0.75"} 2.47e-07
m3storage_database_acquire_lock_latency{namespace="default",quantile="0.95"} 0.000300133
m3storage_database_acquire_lock_latency{namespace="default",quantile="0.99"} 0.001348737
